### PR TITLE
ci(master): run "last-updated" script before build DEV-136

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -37,6 +37,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add source
           git commit -m "last updated"
+          git diff HEAD^ HEAD
           git push
 
   build:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -7,14 +7,47 @@ on:
     branches: [ master ]
 
 jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          architecture: 'x64'
+
+      - name: Run last-updated script
+        run: ./scripts/last-updated.py
+
+      - name: Check if files were updated
+        id: check_status
+        run: |
+          if [[ -n $(git status source --porcelain) ]]; then
+              echo "changes=true" >> "$GITHUB_OUTPUT";
+          fi
+
+      - name: Commit changes
+        if: steps.check_status.outputs.changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add source
+          git commit -m "last updated"
+          git push
+
   build:
+    needs: update
     runs-on: ubuntu-latest
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.12
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         # Semantic version range syntax or exact version of a Python version
         python-version: '3.12'
@@ -43,7 +76,7 @@ jobs:
       run: touch _build/html/.nojekyll
 
     - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/html

--- a/scripts/last-updated.py
+++ b/scripts/last-updated.py
@@ -85,8 +85,6 @@ def update_file(path):
     else:
         fs.insert(1, text)
 
-    sys.stdout.write(text)
-
     with open(path, 'w') as f:
         sys.stdout.write(f'Updating: {path}\n')
         f.write(''.join(fs))

--- a/scripts/last-updated.py
+++ b/scripts/last-updated.py
@@ -18,6 +18,7 @@ GIT_IGNORE_HASHES = [
     '74dc12829b7ae2ce0c6c36364c5791b9f94d489d',
     'bd2708397b2a21ea9fd7699ff0e50cbc3899ad63',
     'dead802312349a42727c6f3339d45892db4cabce',
+    '150a514b59fe22d6efd5c4c83960ecad1e69424b',
 ]
 GIT_IGNORE_MSG = 'last updated'
 RECENTLY_UPDATED_FILE = 'source/recently_updated.md'
@@ -47,7 +48,6 @@ def get_git_data(path):
         ) or msg.startswith(GIT_IGNORE_MSG):
             return _get_hash_and_date(items[1:])
         return _hash, date
-
     return _get_hash_and_date(stdout)
 
 
@@ -84,6 +84,8 @@ def update_file(path):
         fs[1] = text
     else:
         fs.insert(1, text)
+
+    sys.stdout.write(text)
 
     with open(path, 'w') as f:
         sys.stdout.write(f'Updating: {path}\n')


### PR DESCRIPTION
We have a script for automatically updating the "last updated" dates on the articles in this docs repo. But it currently needs to be run manually and the content team cannot do this. This PR adds a job to the CI prod workflow to run the script automatically. If any changes are made by the script, a commit is made and pushed to `master`.

For testing, I made a separate CI workflow on this branch. I removed that workflow after moving the code into `prod.yml`, but the [resulting job](https://github.com/kobotoolbox/docs/actions/runs/14663648321/job/41153371651) is still visible. 