### PR TITLE
Comment out python requirements to test deployment resilience

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -74,8 +74,8 @@ jobs:
     - name: Activate virtual environment
       run: source koboenv/bin/activate
 
-    - name: Install requirements
-      run: pip install -r requirements.txt
+#    - name: Install requirements
+#      run: pip install -r requirements.txt
 
     - name: Build public files
       run: make html


### PR DESCRIPTION
Comment out the python requirements in an attempt to break the deployment