### PR TITLE
chore: update last updated commit hash in migrating_api

### DIFF
--- a/locales/ar/migrating_api.md
+++ b/locales/ar/migrating_api.md
@@ -1,5 +1,5 @@
 # الترحيل من واجهة برمجة التطبيقات v1 إلى v2
-**آخر تحديث:** <a href="https://github.com/kobotoolbox/docs/blob/7a618b1d0f3bc3dffa450c17d9e5063ca4c69770/source/migrating_api.md" class="reference">7 أغسطس 2025</a>
+**آخر تحديث:** <a href="https://github.com/kobotoolbox/docs/blob/76cb7b24ef029f1fbd8eb912e39e28f83165f571/source/migrating_api.md" class="reference">7 أغسطس 2025</a>
 
 كجزء من جهودنا المستمرة لتبسيط وتحديث منصة KoboToolbox، نقوم بإيقاف نقاط نهاية KPI وKoboCAT `v1` تدريجياً. جميع نقاط نهاية KPI وKoboCAT `v1` أصبحت الآن قديمة، وسيتم إزالتها بالكامل في يناير 2026. يتم إيقاف نقاط نهاية `v1` تدريجياً لصالح واجهة برمجة التطبيقات KPI `v2` الأكثر قوة والمدعومة بالكامل.
 

--- a/locales/es/migrating_api.md
+++ b/locales/es/migrating_api.md
@@ -1,5 +1,5 @@
 # Migración de la API v1 a v2
-**Última actualización:** <a href="https://github.com/kobotoolbox/docs/blob/7a618b1d0f3bc3dffa450c17d9e5063ca4c69770/source/migrating_api.md" class="reference">7 ago 2025</a>
+**Última actualización:** <a href="https://github.com/kobotoolbox/docs/blob/76cb7b24ef029f1fbd8eb912e39e28f83165f571/source/migrating_api.md" class="reference">7 ago 2025</a>
 
 Como parte de nuestros esfuerzos continuos para optimizar y modernizar la plataforma KoboToolbox, estamos eliminando gradualmente los endpoints `v1` de KPI y KoboCAT. Todos los endpoints `v1` de KPI y KoboCAT están ahora obsoletos y se eliminarán por completo en enero de 2026. Los endpoints `v1` están siendo reemplazados por la API KPI `v2`, que es más robusta y cuenta con soporte completo.
 

--- a/locales/fr/migrating_api.md
+++ b/locales/fr/migrating_api.md
@@ -1,5 +1,5 @@
 # Migration de l'API v1 vers v2
-**Dernière mise à jour :** <a href="https://github.com/kobotoolbox/docs/blob/7a618b1d0f3bc3dffa450c17d9e5063ca4c69770/source/migrating_api.md" class="reference">7 août 2025</a>
+**Dernière mise à jour :** <a href="https://github.com/kobotoolbox/docs/blob/76cb7b24ef029f1fbd8eb912e39e28f83165f571/source/migrating_api.md" class="reference">7 août 2025</a>
 
 Dans le cadre de nos efforts continus pour rationaliser et moderniser la plateforme KoboToolbox, nous supprimons progressivement les points de terminaison KPI et KoboCAT `v1`. Tous les points de terminaison KPI et KoboCAT `v1` sont désormais obsolètes et seront entièrement supprimés en janvier 2026. Les points de terminaison `v1` sont progressivement supprimés au profit de l'API KPI `v2`, plus robuste et entièrement prise en charge.
 

--- a/source/migrating_api.md
+++ b/source/migrating_api.md
@@ -1,5 +1,5 @@
 # Migrating from v1 to v2 API
-**Last updated:** <a href="https://github.com/kobotoolbox/docs/blob/6ad0e952d9c91d0b0fc2d20b46ee26cf76ddfd5e/source/migrating_api.md" class="reference">25 May 2026</a>
+**Last updated:** <a href="https://github.com/kobotoolbox/docs/blob/76cb7b24ef029f1fbd8eb912e39e28f83165f571/source/migrating_api.md" class="reference">25 May 2026</a>
 
 
 As part of our ongoing efforts to streamline and modernize the KoboToolbox platform, we are phasing out KPI and KoboCAT `v1` endpoints. All KPI and KoboCAT `v1` endpoints are now deprecated, and will be removed entirely in June 2026. `v1` endpoints are being phased out in favor of the more robust and fully supported KPI `v2` API.


### PR DESCRIPTION
## Notes
Updates the \"Last updated\" commit hash in `migrating_api.md` across all 4 files (source, fr, es, ar) to point to the correct merge commit `76cb7b24`.